### PR TITLE
Subject: Ignore Next.js build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 
 .env
+.next


### PR DESCRIPTION
Add `.next` to the `.gitignore` file to prevent committing the build output generated by Next.js. This keeps the repository clean and avoids unnecessary file tracking.